### PR TITLE
Add console script to hvor

### DIFF
--- a/hvor/__init__.py
+++ b/hvor/__init__.py
@@ -1,1 +1,2 @@
 from hvor.hvor import point, points
+from hvor.console import main

--- a/hvor/console.py
+++ b/hvor/console.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import sys
+import json
+from .hvor import point
+
+
+def _exit_with_usage(msg=None):
+    if not msg:
+        print("Usage: hvor p1 p2")
+        sys.exit()
+    else:
+        # exit code = 1 when sys.exit receives message
+        sys.exit(msg)
+
+
+def _print_point_to_json(p1: float, p2: float) -> None:
+    """This function is called when hvor is called from the console.
+    It prints the point dict to std.out.
+    """
+    pt = point(p1, p2)
+    print(json.dumps(pt, indent=4))
+
+
+def main():
+    if "-h" in sys.argv or "--help" in sys.argv:
+        _exit_with_usage()
+    if len(sys.argv) != 3:
+        exit("Usage: hvor p1 p2")
+    s1 = sys.argv[1]
+    s2 = sys.argv[2]
+    try:
+        f1, f2 = float(s1), float(s2)
+    except ValueError as err:
+        msg = f"hvor takes two floating point numbers: {err}"
+        _exit_with_usage(msg)
+    _print_point_to_json(f1, f2)
+
+
+if __name__ == "__main__":
+    main()

--- a/hvor/console.py
+++ b/hvor/console.py
@@ -25,7 +25,7 @@ def main():
     if "-h" in sys.argv or "--help" in sys.argv:
         _exit_with_usage()
     if len(sys.argv) != 3:
-        exit("Usage: hvor p1 p2")
+        _exit_with_usage("Usage: hvor lat lon")
     s1 = sys.argv[1]
     s2 = sys.argv[2]
     try:

--- a/hvor/console.py
+++ b/hvor/console.py
@@ -6,18 +6,18 @@ from .hvor import point
 
 def _exit_with_usage(msg=None):
     if not msg:
-        print("Usage: hvor p1 p2")
+        print("Usage: hvor lat lon")
         sys.exit()
     else:
         # exit code = 1 when sys.exit receives message
         sys.exit(msg)
 
 
-def _print_point_to_json(p1: float, p2: float) -> None:
+def _print_point_to_json(lat: float, lon: float) -> None:
     """This function is called when hvor is called from the console.
     It prints the point dict to std.out.
     """
-    pt = point(p1, p2)
+    pt = point(lat, lon)
     print(json.dumps(pt, indent=4))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ readme = "README.md"
 repository = "https://github.com/bkkas/iout_foss"
 
 include = ["CHANGELOG.md"]
+
+[tool.poetry.scripts]
+hvor = 'hvor.console:main'
+
 [tool.poetry.dependencies]
 python = "^3.8"
 geopandas = "^0.9.0"


### PR DESCRIPTION
A new file `hvor.console` adds a function `main()` that when called, reads two points from `sys.argv` and prints the `json` to standard out.

Usage examples:

```bash

# happy path -- exit code = 0

[pgdr@uib] hvor 60.384140 5.331593
{
    "kommunenummer": [
        4601
    ],
    "kommune": [
        "Bergen"
    ],
    "fylkesnummer": [
        46
    ],
    "fylke": [
        "Vestland"
    ]
}

# help -- exit code = 0

[pgdr@uib] hvor -h
Usage: hvor p1 p2
[pgdr@uib] hvor --help
Usage: hvor p1 p2


# error in format -- exit code = 1

[pgdr@uib] hvor 60.3 1.2.3
hvor takes two floating point numbers: could not convert string to float: '1.2.3'


# outputs valid json

[pgdr@uib] hvor 60.384140 5.331593 | jq "."
{
  "kommunenummer": [
    4601
  ],
  "kommune": [
    "Bergen"
  ],
  "fylkesnummer": [
    46
  ],
  "fylke": [
    "Vestland"
  ]
}

```