### PR TITLE
Only trigger release pipeline on published event

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -2,6 +2,7 @@ name: Build and publish package
 
 on:
   release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
To avoid 3 parallel Github actions being triggered