### PR TITLE
Publish to hvor version to pypi using git version tag

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -24,5 +24,6 @@ jobs:
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       run: |
+        poetry version $(git describe --tags --abbrev=0)
         poetry config pypi-token.pypi $PYPI_TOKEN
         poetry publish --build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.poetry]
 name = "hvor"
-version = "0.0.0"
+version = "0.0.0"  # publish pipeline sets sets version to current git tag
 description = "A library for assigning Norwegian metadata to coordinates"
 authors = ["Espen Hafstad Solvang, Erik Parmann, Kristian Flikka, Anna-Lena Both, Pål Grønås Drange"]
-#license = "unknown :("
+license = "LGPL-3.0"
 keywords = ["pandas", "dataframe", "geopandas"]
 readme = "README.md"
 repository = "https://github.com/bkkas/iout_foss"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hvor"
-version = "0.2.0"
+version = "0.0.0"
 description = "A library for assigning Norwegian metadata to coordinates"
 authors = ["Espen Hafstad Solvang, Erik Parmann, Kristian Flikka, Anna-Lena Both, Pål Grønås Drange"]
 #license = "unknown :("


### PR DESCRIPTION
Now we don't have to modify pyproject.toml version as poetry will use the git release tag to set the `hvor` version before publishing to pypi.

As described here: https://www.nicholasnadeau.com/post/2020/8/one-version-to-rule-them-all-keeping-your-python-package-version-number-in-sync-with-git-and-poetry/