### PR TITLE
Infer package version in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,5 @@
+import os
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full
@@ -22,7 +24,7 @@ copyright = "2021, Espen Hafstad Solvang"
 author = "Espen Hafstad Solvang"
 
 # The full version, including alpha/beta/rc tags
-release = "v0.1.2"
+release = os.popen("git describe --tags --abbrev=0").read()  # e.g. 0.2.1
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
So that readthedocs version can stay updated with git tags, and we don't have to manually change anything else.

(not sure if readthedocs builder will protest with a git command...)